### PR TITLE
Remove package-cleanup_oldkernels

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,29 +62,4 @@ class yum (
   yum::config { 'gpgcheck':
     ensure => bool2num($gpgcheck)
   }
-
-  yum::config { 'installonly_limit':
-    ensure => $installonly_limit,
-    notify => Exec['package-cleanup_oldkernels'],
-  }
-
-  # cleanup old kernels
-  ensure_packages(['yum-utils'])
-
-  $_pc_cmd = delete_undef_values([
-    '/usr/bin/package-cleanup',
-    '--oldkernels',
-    "--count=${installonly_limit}",
-    '-y',
-    $keep_kernel_devel ? {
-      true    => '--keepdevel',
-      default => undef,
-    },
-  ])
-
-  exec { 'package-cleanup_oldkernels':
-    command     => shellquote($_pc_cmd),
-    refreshonly => true,
-    require     => Package['yum-utils'],
-  }
 }


### PR DESCRIPTION
Under some circumstances to avoid dependency cycle it is necessary to remove the part regarding  package-cleanup_oldkernels.
